### PR TITLE
Renamed `thumbnailView` => `transitionSourceView`

### DIFF
--- a/Demo/ImageViewerDemo/PhotosViewController.swift
+++ b/Demo/ImageViewerDemo/PhotosViewController.swift
@@ -177,7 +177,7 @@ extension PhotosViewController: ImageViewerDataSource {
         }
     }
     
-    func thumbnailView(forCurrentPageOf imageViewer: ImageViewerViewController) -> UIImageView? {
+    func transitionSourceView(forCurrentPageOf imageViewer: ImageViewerViewController) -> UIImageView? {
         let currentPage = imageViewer.currentPage
         let indexPathForCurrentImage = IndexPath(item: currentPage, section: 0)
         guard let cellForCurrentImage = collectionView.cellForItem(at: indexPathForCurrentImage) as? PhotoCell else {

--- a/Sources/ImageViewer/ImageViewerViewController.swift
+++ b/Sources/ImageViewer/ImageViewerViewController.swift
@@ -49,16 +49,16 @@ public protocol ImageViewerDataSource: AnyObject {
     func imageViewer(_ imageViewer: ImageViewerViewController,
                      imageSourceAtPage page: Int) -> ImageSource
     
-    /// Asks the data source to return the thumbnail view for the current page of the image viewer.
+    /// Asks the data source to return the transition source image view for the current page of the image viewer.
     ///
-    /// The image viewer uses this thumbnail view for push or pop transitions.
-    /// On the push transition, an animation runs as the image expands from this thumbnail view. The reverse happens on the pop.
+    /// The image viewer uses this view for push or pop transitions.
+    /// On the push transition, an animation runs as the image expands from this view. The reverse happens on the pop.
     ///
     /// If `nil`, the default animation runs on the transition.
     ///
     /// - Parameter imageViewer: An object representing the image viewer requesting this information.
-    /// - Returns: The thumbnail view for current page of `imageViewer`.
-    func thumbnailView(forCurrentPageOf imageViewer: ImageViewerViewController) -> UIImageView?
+    /// - Returns: The transition source view for current page of `imageViewer`.
+    func transitionSourceView(forCurrentPageOf imageViewer: ImageViewerViewController) -> UIImageView?
 }
 
 // MARK: - ImageViewerViewController -
@@ -246,11 +246,11 @@ open class ImageViewerViewController: UIPageViewController {
     @objc
     private func panned(recognizer: UIPanGestureRecognizer) {
         // Check whether to transition interactively
-        guard let sourceThumbnailView = imageViewerDataSource?.thumbnailView(forCurrentPageOf: self) else { return }
+        guard let sourceImageView = imageViewerDataSource?.transitionSourceView(forCurrentPageOf: self) else { return }
         
         if recognizer.state == .began {
             // Start the interactive pop transition
-            interactivePopTransition = .init(sourceThumbnailView: sourceThumbnailView)
+            interactivePopTransition = .init(sourceImageView: sourceImageView)
             navigationController?.popViewController(animated: true)
         }
         
@@ -355,8 +355,8 @@ extension ImageViewerViewController: UINavigationControllerDelegate {
                                      animationControllerFor operation: UINavigationController.Operation,
                                      from fromVC: UIViewController,
                                      to toVC: UIViewController) -> (any UIViewControllerAnimatedTransitioning)? {
-        guard let sourceThumbnailView = imageViewerDataSource?.thumbnailView(forCurrentPageOf: self) else { return nil }
-        return ImageViewerTransition(operation: operation, sourceThumbnailView: sourceThumbnailView)
+        guard let sourceImageView = imageViewerDataSource?.transitionSourceView(forCurrentPageOf: self) else { return nil }
+        return ImageViewerTransition(operation: operation, sourceImageView: sourceImageView)
     }
     
     public func navigationController(_ navigationController: UINavigationController,

--- a/Sources/ImageViewer/Transitions/ImageViewerInteractivePopTransition.swift
+++ b/Sources/ImageViewer/Transitions/ImageViewerInteractivePopTransition.swift
@@ -9,22 +9,22 @@ import UIKit
 
 final class ImageViewerInteractivePopTransition: NSObject {
     
-    private let sourceThumbnailView: UIImageView
+    private let sourceImageView: UIImageView
     
     private var animator: UIViewPropertyAnimator?
     private var transitionContext: (any UIViewControllerContextTransitioning)?
     
     // MARK: Backups
     
-    private var thumbnailHiddenBackup = false
+    private var sourceImageHiddenBackup = false
     private var initialZoomScale: CGFloat = 1
     private var initialImageTransform = CGAffineTransform.identity
     private var initialImageFrameInContainer = CGRect.null
     
     // MARK: - Initializers
     
-    init(sourceThumbnailView: UIImageView) {
-        self.sourceThumbnailView = sourceThumbnailView
+    init(sourceImageView: UIImageView) {
+        self.sourceImageView = sourceImageView
         super.init()
     }
 }
@@ -44,7 +44,7 @@ extension ImageViewerInteractivePopTransition: UIViewControllerInteractiveTransi
         let currentPageImageView = currentPageView.imageView
         
         // Back up
-        thumbnailHiddenBackup = sourceThumbnailView.isHidden
+        sourceImageHiddenBackup = sourceImageView.isHidden
         initialZoomScale = currentPageView.scrollView.zoomScale
         initialImageTransform = currentPageImageView.transform
         initialImageFrameInContainer = containerView.convert(currentPageImageView.frame,
@@ -59,7 +59,7 @@ extension ImageViewerInteractivePopTransition: UIViewControllerInteractiveTransi
         containerView.addSubview(fromView)
         containerView.addSubview(currentPageImageView)
         
-        sourceThumbnailView.isHidden = true
+        sourceImageView.isHidden = true
         
         // Animation
         animator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1) {
@@ -79,14 +79,14 @@ extension ImageViewerInteractivePopTransition: UIViewControllerInteractiveTransi
         let currentPageImageView = currentPageView.imageView
         
         let finishAnimator = UIViewPropertyAnimator(duration: duration, dampingRatio: 1) {
-            let thumbnailFrameInContainer = containerView.convert(self.sourceThumbnailView.frame,
-                                                                  from: self.sourceThumbnailView)
-            currentPageImageView.frame = thumbnailFrameInContainer
-            currentPageImageView.transitioningConfiguration = self.sourceThumbnailView.transitioningConfiguration
-            currentPageImageView.layer.masksToBounds = true // TODO: Change according to the thumbnail configuration
+            let sourceImageFrameInContainer = containerView.convert(self.sourceImageView.frame,
+                                                                    from: self.sourceImageView)
+            currentPageImageView.frame = sourceImageFrameInContainer
+            currentPageImageView.transitioningConfiguration = self.sourceImageView.transitioningConfiguration
+            currentPageImageView.layer.masksToBounds = true // TODO: Change according to the source configuration
         }
         finishAnimator.addCompletion { _ in
-            self.sourceThumbnailView.isHidden = self.thumbnailHiddenBackup
+            self.sourceImageView.isHidden = self.sourceImageHiddenBackup
             currentPageView.removeFromSuperview()
             currentPageImageView.removeFromSuperview()
             transitionContext.completeTransition(true)
@@ -110,7 +110,7 @@ extension ImageViewerInteractivePopTransition: UIViewControllerInteractiveTransi
         }
         cancelAnimator.addCompletion { _ in
             // Restore to pre-transition state
-            self.sourceThumbnailView.isHidden = self.thumbnailHiddenBackup
+            self.sourceImageView.isHidden = self.sourceImageHiddenBackup
             currentPageImageView.updateAnchorPointWithoutMoving(.init(x: 0.5, y: 0.5))
             currentPageImageView.transform = self.initialImageTransform
             currentPageView.restoreLayoutConfigurationAfterTransition()

--- a/Sources/ImageViewer/Transitions/ImageViewerTransition.swift
+++ b/Sources/ImageViewer/Transitions/ImageViewerTransition.swift
@@ -10,14 +10,14 @@ import UIKit
 final class ImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioning {
     
     let operation: UINavigationController.Operation
-    let sourceThumbnailView: UIImageView
+    let sourceImageView: UIImageView
     
     // MARK: - Initializers
     
     init(operation: UINavigationController.Operation,
-         sourceThumbnailView: UIImageView) {
+         sourceImageView: UIImageView) {
         self.operation = operation
-        self.sourceThumbnailView = sourceThumbnailView
+        self.sourceImageView = sourceImageView
     }
     
     // MARK: - Methods
@@ -60,7 +60,7 @@ final class ImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioni
         containerView.addSubview(imageViewerView)
         
         // Back up
-        let thumbnailHiddenBackup = sourceThumbnailView.isHidden
+        let sourceImageHiddenBackup = sourceImageView.isHidden
         
         // Prepare for transition
         imageViewerView.frame = transitionContext.finalFrame(for: imageViewer)
@@ -70,20 +70,20 @@ final class ImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioni
         let currentPageView = imageViewer.currentPageViewController.imageViewerOnePageView
         let currentPageImageView = currentPageView.imageView
         if currentPageImageView.image == nil {
-            currentPageView.setImage(sourceThumbnailView.image, with: .none)
+            currentPageView.setImage(sourceImageView.image, with: .none)
         }
         
         let configurationBackup = currentPageImageView.transitioningConfiguration
         let currentPageImageFrameInContainer = containerView.convert(currentPageImageView.frame,
                                                                      from: currentPageImageView)
-        let thumbnailFrameInContainer = containerView.convert(sourceThumbnailView.frame,
-                                                              from: sourceThumbnailView)
+        let sourceImageFrameInContainer = containerView.convert(sourceImageView.frame,
+                                                                from: sourceImageView)
         currentPageView.destroyLayoutConfigurationBeforeTransition()
-        currentPageImageView.transitioningConfiguration = sourceThumbnailView.transitioningConfiguration
-        currentPageImageView.frame = thumbnailFrameInContainer
+        currentPageImageView.transitioningConfiguration = sourceImageView.transitioningConfiguration
+        currentPageImageView.frame = sourceImageFrameInContainer
         currentPageImageView.layer.masksToBounds = true
         containerView.addSubview(currentPageImageView)
-        sourceThumbnailView.isHidden = true
+        sourceImageView.isHidden = true
         
         // Animation
         let duration = transitionDuration(using: transitionContext)
@@ -93,7 +93,7 @@ final class ImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioni
             currentPageImageView.transitioningConfiguration = configurationBackup
             
             // NOTE: Keep following properties during transition for smooth animation
-            currentPageImageView.contentMode = self.sourceThumbnailView.contentMode
+            currentPageImageView.contentMode = self.sourceImageView.contentMode
             currentPageImageView.layer.masksToBounds = true
         }
         animator.addCompletion { position in
@@ -101,7 +101,7 @@ final class ImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioni
             case .end:
                 currentPageImageView.transitioningConfiguration = configurationBackup
                 currentPageView.restoreLayoutConfigurationAfterTransition()
-                self.sourceThumbnailView.isHidden = thumbnailHiddenBackup
+                self.sourceImageView.isHidden = sourceImageHiddenBackup
                 transitionContext.completeTransition(true)
             case .start, .current:
                 assertionFailure()
@@ -126,7 +126,7 @@ final class ImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioni
         containerView.addSubview(toView)
         
         // Back up
-        let thumbnailHiddenBackup = sourceThumbnailView.isHidden
+        let sourceImageHiddenBackup = sourceImageView.isHidden
         
         // Prepare for transition
         toView.frame = transitionContext.finalFrame(for: toVC)
@@ -137,26 +137,26 @@ final class ImageViewerTransition: NSObject, UIViewControllerAnimatedTransitioni
         let currentPageImageView = currentPageView.imageView
         let currentPageImageFrameInContainer = containerView.convert(currentPageImageView.frame,
                                                                      from: currentPageView.scrollView)
-        let thumbnailFrameInContainer = containerView.convert(sourceThumbnailView.frame,
-                                                              from: sourceThumbnailView)
+        let sourceImageFrameInContainer = containerView.convert(sourceImageView.frame,
+                                                                from: sourceImageView)
         currentPageView.destroyLayoutConfigurationBeforeTransition()
         currentPageImageView.frame = currentPageImageFrameInContainer
         containerView.addSubview(currentPageImageView)
-        sourceThumbnailView.isHidden = true
+        sourceImageView.isHidden = true
         
         // Animation
         let duration = transitionDuration(using: transitionContext)
         let animator = UIViewPropertyAnimator(duration: duration, dampingRatio: 1) {
             toView.alpha = 1
-            currentPageImageView.frame = thumbnailFrameInContainer
-            currentPageImageView.transitioningConfiguration = self.sourceThumbnailView.transitioningConfiguration
-            currentPageImageView.clipsToBounds = true // TODO: Change according to the thumbnail configuration
+            currentPageImageView.frame = sourceImageFrameInContainer
+            currentPageImageView.transitioningConfiguration = self.sourceImageView.transitioningConfiguration
+            currentPageImageView.clipsToBounds = true // TODO: Change according to the source configuration
         }
         animator.addCompletion { position in
             switch position {
             case .end:
                 currentPageImageView.removeFromSuperview()
-                self.sourceThumbnailView.isHidden = thumbnailHiddenBackup
+                self.sourceImageView.isHidden = sourceImageHiddenBackup
                 transitionContext.completeTransition(true)
             case .start, .current:
                 assertionFailure()


### PR DESCRIPTION
# Changes
- Replaced the term "thumbnail view" with "transition source image view".
  - The term "thumbnail" will be used in paging scroll bar.