### PR TITLE
Fixed reloading animation when media is just moved

### DIFF
--- a/Sources/MediaViewer/Extensions/Sequence+Extension.swift
+++ b/Sources/MediaViewer/Extensions/Sequence+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  Sequence+Extension.swift
+//
+//
+//  Created by Yusaku Nishi on 2023/12/17.
+//
+
+extension Sequence {
+    
+    func subtracting(_ other: Self) -> [Element] where Element: Equatable {
+        // TODO: Improve subtraction algorithm
+        var subtracted: [Element] = []
+        for element in self {
+            if !other.contains(element) {
+                subtracted.append(element)
+            }
+        }
+        return subtracted
+    }
+}

--- a/Sources/MediaViewer/Extensions/Sequence+Extension.swift
+++ b/Sources/MediaViewer/Extensions/Sequence+Extension.swift
@@ -19,4 +19,16 @@ extension Sequence {
         }
         return subtracted
     }
+    
+    func subtracting2(
+        _ other: some Sequence<Element>
+    ) -> [Element] where Element: Hashable {
+        Set(self).subtracting(Set(other))
+    }
+    
+    func subtracting3(
+        _ other: some Sequence<Element>
+    ) -> [Element] where Element: Hashable {
+        Set(self).subtracting(other)
+    }
 }

--- a/Sources/MediaViewer/Extensions/Sequence+Extension.swift
+++ b/Sources/MediaViewer/Extensions/Sequence+Extension.swift
@@ -7,7 +7,9 @@
 
 extension Sequence {
     
-    func subtracting(_ other: Self) -> [Element] where Element: Equatable {
+    func subtracting(
+        _ other: some Sequence<Element>
+    ) -> [Element] where Element: Equatable {
         // TODO: Improve subtraction algorithm
         var subtracted: [Element] = []
         for element in self {

--- a/Sources/MediaViewer/Extensions/Sequence+Extension.swift
+++ b/Sources/MediaViewer/Extensions/Sequence+Extension.swift
@@ -5,30 +5,9 @@
 //  Created by Yusaku Nishi on 2023/12/17.
 //
 
-extension Sequence {
+extension Sequence where Element: Hashable {
     
-    func subtracting(
-        _ other: some Sequence<Element>
-    ) -> [Element] where Element: Equatable {
-        // TODO: Improve subtraction algorithm
-        var subtracted: [Element] = []
-        for element in self {
-            if !other.contains(element) {
-                subtracted.append(element)
-            }
-        }
-        return subtracted
-    }
-    
-    func subtracting2(
-        _ other: some Sequence<Element>
-    ) -> [Element] where Element: Hashable {
+    func subtracting(_ other: some Sequence<Element>) -> Set<Element> {
         Set(self).subtracting(Set(other))
-    }
-    
-    func subtracting3(
-        _ other: some Sequence<Element>
-    ) -> [Element] where Element: Hashable {
-        Set(self).subtracting(other)
     }
 }

--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -463,17 +463,12 @@ open class MediaViewerViewController: UIPageViewController {
     /// - Parameter animated: Whether to animate the reloading.
     open func reloadMedia(animated: Bool) async {
         let newIdentifiers = fetchMediaIdentifiers()
-        
         let currentIdentifiers = mediaViewerVM.mediaIdentifiers
         guard newIdentifiers != currentIdentifiers else { return }
         
-        // TODO: Improve algorithm to extract deleted identifiers
-        var deletingIdentifiers: [AnyMediaIdentifier] = []
-        for identifier in currentIdentifiers {
-            if !newIdentifiers.contains(identifier) {
-                deletingIdentifiers.append(identifier)
-            }
-        }
+        let deletingIdentifiers = currentIdentifiers.subtracting(
+            newIdentifiers
+        )
         
         let visibleVCBeforeReloading = currentPageViewController
         

--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -474,8 +474,7 @@ open class MediaViewerViewController: UIPageViewController {
         
         let pagingAfterReloading = mediaViewerVM.paging(
             afterDeleting: deletingIdentifiers,
-            currentIdentifier: visibleVCBeforeReloading.mediaIdentifier,
-            finalIdentifiers: newIdentifiers
+            currentIdentifier: visibleVCBeforeReloading.mediaIdentifier
         )
         if let pagingAfterReloading {
             destinationPageVCAfterReloading = makeMediaViewerPage(

--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -506,7 +506,7 @@ open class MediaViewerViewController: UIPageViewController {
     }
     
     private func reloadMedia(
-        deleting deletedIdentifiers: [AnyMediaIdentifier],
+        deleting deletedIdentifiers: some Sequence<AnyMediaIdentifier>,
         visibleVCBeforeReloading: MediaViewerOnePageViewController,
         pagingAfterReloading: MediaViewerViewModel.PagingAfterReloading?,
         animated: Bool

--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -464,11 +464,16 @@ open class MediaViewerViewController: UIPageViewController {
     open func reloadMedia(animated: Bool) async {
         let newIdentifiers = fetchMediaIdentifiers()
         
-        let difference = newIdentifiers.difference(
-            from: mediaViewerVM.mediaIdentifiers
-        )
-        guard !difference.isEmpty else { return }
-        let deletingIdentifiers = difference.removals.map(\.element)
+        let currentIdentifiers = mediaViewerVM.mediaIdentifiers
+        guard newIdentifiers != currentIdentifiers else { return }
+        
+        // TODO: Improve algorithm to extract deleted identifiers
+        var deletingIdentifiers: [AnyMediaIdentifier] = []
+        for identifier in currentIdentifiers {
+            if !newIdentifiers.contains(identifier) {
+                deletingIdentifiers.append(identifier)
+            }
+        }
         
         let visibleVCBeforeReloading = currentPageViewController
         

--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -474,7 +474,8 @@ open class MediaViewerViewController: UIPageViewController {
         
         let pagingAfterReloading = mediaViewerVM.paging(
             afterDeleting: deletingIdentifiers,
-            currentIdentifier: visibleVCBeforeReloading.mediaIdentifier
+            currentIdentifier: visibleVCBeforeReloading.mediaIdentifier,
+            finalIdentifiers: newIdentifiers
         )
         if let pagingAfterReloading {
             destinationPageVCAfterReloading = makeMediaViewerPage(

--- a/Sources/MediaViewer/MediaViewerViewModel.swift
+++ b/Sources/MediaViewer/MediaViewerViewModel.swift
@@ -65,16 +65,9 @@ extension MediaViewerViewModel {
     
     func paging(
         afterDeleting deletingIdentifiers: [AnyMediaIdentifier],
-        currentIdentifier: AnyMediaIdentifier,
-        finalIdentifiers: [AnyMediaIdentifier]
+        currentIdentifier: AnyMediaIdentifier
     ) -> PagingAfterReloading? {
-        /*
-         * NOTE:
-         * finalIdentifiers should be checked instead of deletingIdentifiers
-         * because deletingIdentifiers may contain currentIdentifiers
-         * even if items are just reordered.
-         */
-        guard !finalIdentifiers.contains(currentIdentifier) else {
+        guard deletingIdentifiers.contains(currentIdentifier) else {
             // Stay on the current page
             return .init(
                 destinationIdentifier: currentIdentifier,
@@ -108,7 +101,6 @@ extension MediaViewerViewModel {
         }
         
         // When all pages are deleted, close the viewer and do not perform paging animation
-        assert(finalIdentifiers.isEmpty)
         return nil
     }
 }

--- a/Sources/MediaViewer/MediaViewerViewModel.swift
+++ b/Sources/MediaViewer/MediaViewerViewModel.swift
@@ -64,7 +64,7 @@ extension MediaViewerViewModel {
     }
     
     func paging(
-        afterDeleting deletingIdentifiers: [AnyMediaIdentifier],
+        afterDeleting deletingIdentifiers: some Sequence<AnyMediaIdentifier>,
         currentIdentifier: AnyMediaIdentifier
     ) -> PagingAfterReloading? {
         guard deletingIdentifiers.contains(currentIdentifier) else {

--- a/Sources/MediaViewer/MediaViewerViewModel.swift
+++ b/Sources/MediaViewer/MediaViewerViewModel.swift
@@ -65,9 +65,16 @@ extension MediaViewerViewModel {
     
     func paging(
         afterDeleting deletingIdentifiers: [AnyMediaIdentifier],
-        currentIdentifier: AnyMediaIdentifier
+        currentIdentifier: AnyMediaIdentifier,
+        finalIdentifiers: [AnyMediaIdentifier]
     ) -> PagingAfterReloading? {
-        guard deletingIdentifiers.contains(currentIdentifier) else {
+        /*
+         * NOTE:
+         * finalIdentifiers should be checked instead of deletingIdentifiers
+         * because deletingIdentifiers may contain currentIdentifiers
+         * even if items are just reordered.
+         */
+        guard !finalIdentifiers.contains(currentIdentifier) else {
             // Stay on the current page
             return .init(
                 destinationIdentifier: currentIdentifier,
@@ -101,6 +108,7 @@ extension MediaViewerViewModel {
         }
         
         // When all pages are deleted, close the viewer and do not perform paging animation
+        assert(finalIdentifiers.isEmpty)
         return nil
     }
 }

--- a/Sources/MediaViewer/PageControlBar/MediaViewerPageControlBar.swift
+++ b/Sources/MediaViewer/PageControlBar/MediaViewerPageControlBar.swift
@@ -429,7 +429,9 @@ extension MediaViewerPageControlBar {
     /// `loadItems(_:expandingItemWith:animated:)` after this animation is finished.
     ///
     /// - Parameter identifiers: Identifiers for media to perform vanish animation.
-    func performVanishAnimationBody(for identifiers: [AnyMediaIdentifier]) {
+    func performVanishAnimationBody(
+        for identifiers: some Sequence<AnyMediaIdentifier>
+    ) {
         assert(state == .reloading)
         
         for identifier in identifiers {

--- a/Tests/MediaViewerTests/MediaViewerViewModelTests.swift
+++ b/Tests/MediaViewerTests/MediaViewerViewModelTests.swift
@@ -30,8 +30,7 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: Array(identifiers[2...3]),
-                    currentIdentifier: identifiers[2],
-                    finalIdentifiers: [identifiers[0], identifiers[1], identifiers[4]]
+                    currentIdentifier: identifiers[2]
                 )
                 
                 // Assert
@@ -51,8 +50,7 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: Array(identifiers[2...]),
-                    currentIdentifier: identifiers[2],
-                    finalIdentifiers: [identifiers[0], identifiers[1]]
+                    currentIdentifier: identifiers[2]
                 )
                 
                 // Assert
@@ -72,8 +70,7 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: identifiers,
-                    currentIdentifier: identifiers[2],
-                    finalIdentifiers: []
+                    currentIdentifier: identifiers[2]
                 )
                 
                 // Assert
@@ -90,8 +87,7 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: [identifiers[1], identifiers[4]],
-                    currentIdentifier: identifiers[2],
-                    finalIdentifiers: [identifiers[0], identifiers[2], identifiers[3]]
+                    currentIdentifier: identifiers[2]
                 )
                 
                 // Assert
@@ -111,8 +107,7 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: [],
-                    currentIdentifier: identifiers[2],
-                    finalIdentifiers: identifiers.reversed()
+                    currentIdentifier: identifiers[2]
                 )
                 
                 // Assert

--- a/Tests/MediaViewerTests/MediaViewerViewModelTests.swift
+++ b/Tests/MediaViewerTests/MediaViewerViewModelTests.swift
@@ -30,7 +30,8 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: Array(identifiers[2...3]),
-                    currentIdentifier: identifiers[2]
+                    currentIdentifier: identifiers[2],
+                    finalIdentifiers: [identifiers[0], identifiers[1], identifiers[4]]
                 )
                 
                 // Assert
@@ -50,7 +51,8 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: Array(identifiers[2...]),
-                    currentIdentifier: identifiers[2]
+                    currentIdentifier: identifiers[2],
+                    finalIdentifiers: [identifiers[0], identifiers[1]]
                 )
                 
                 // Assert
@@ -70,7 +72,8 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: identifiers,
-                    currentIdentifier: identifiers[2]
+                    currentIdentifier: identifiers[2],
+                    finalIdentifiers: []
                 )
                 
                 // Assert
@@ -87,7 +90,8 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: [identifiers[1], identifiers[4]],
-                    currentIdentifier: identifiers[2]
+                    currentIdentifier: identifiers[2],
+                    finalIdentifiers: [identifiers[0], identifiers[2], identifiers[3]]
                 )
                 
                 // Assert
@@ -107,7 +111,8 @@ final class MediaViewerViewModelTests: XCTestCase {
                 // Act
                 let pagingAfterReloading = mediaViewerVM.paging(
                     afterDeleting: [],
-                    currentIdentifier: identifiers[2]
+                    currentIdentifier: identifiers[2],
+                    finalIdentifiers: identifiers.reversed()
                 )
                 
                 // Assert

--- a/Tests/MediaViewerTests/SequenceExtensionTests.swift
+++ b/Tests/MediaViewerTests/SequenceExtensionTests.swift
@@ -1,0 +1,21 @@
+//
+//  SequenceExtensionTests.swift
+//
+//
+//  Created by Yusaku Nishi on 2023/12/17.
+//
+
+import XCTest
+@testable import MediaViewer
+
+final class SequenceExtensionTests: XCTestCase {
+    
+    func testSubtraction() {
+        XCTAssertEqual([0, 1, 2].subtracting([0, 1, 2, 3]), [])
+        XCTAssertEqual([0, 1, 2].subtracting([0, 1, 2]), [])
+        XCTAssertEqual([0, 1, 2].subtracting([0, 1]), [2])
+        XCTAssertEqual([0, 1, 2].subtracting([1]), [0, 2])
+        XCTAssertEqual([0, 1, 2].subtracting([]), [0, 1, 2])
+        XCTAssertEqual([0, 1, 2].subtracting([100]), [0, 1, 2])
+    }
+}

--- a/Tests/MediaViewerTests/SequenceExtensionTests.swift
+++ b/Tests/MediaViewerTests/SequenceExtensionTests.swift
@@ -18,12 +18,4 @@ final class SequenceExtensionTests: XCTestCase {
         XCTAssertEqual([0, 1, 2].subtracting([]), [0, 1, 2])
         XCTAssertEqual([0, 1, 2].subtracting([100]), [0, 1, 2])
     }
-    
-    func testMeasureSubtracting() {
-        measure {
-            _ = (0..<3000).subtracting(
-                stride(from: 0, to: 3000, by: 1)
-            )
-        }
-    }
 }

--- a/Tests/MediaViewerTests/SequenceExtensionTests.swift
+++ b/Tests/MediaViewerTests/SequenceExtensionTests.swift
@@ -18,4 +18,28 @@ final class SequenceExtensionTests: XCTestCase {
         XCTAssertEqual([0, 1, 2].subtracting([]), [0, 1, 2])
         XCTAssertEqual([0, 1, 2].subtracting([100]), [0, 1, 2])
     }
+    
+    func testMeasureSubtracting() {
+        measure {
+            _ = (0..<3000).subtracting(
+                stride(from: 0, to: 3000, by: 1)
+            )
+        }
+    }
+    
+    func testMeasureSubtracting2() {
+        measure {
+            _ = (0..<3000).subtracting2(
+                stride(from: 0, to: 3000, by: 1)
+            )
+        }
+    }
+    
+    func testMeasureSubtracting3() {
+        measure {
+            _ = (0..<3000).subtracting3(
+                stride(from: 0, to: 3000, by: 1)
+            )
+        }
+    }
 }

--- a/Tests/MediaViewerTests/SequenceExtensionTests.swift
+++ b/Tests/MediaViewerTests/SequenceExtensionTests.swift
@@ -26,20 +26,4 @@ final class SequenceExtensionTests: XCTestCase {
             )
         }
     }
-    
-    func testMeasureSubtracting2() {
-        measure {
-            _ = (0..<3000).subtracting2(
-                stride(from: 0, to: 3000, by: 1)
-            )
-        }
-    }
-    
-    func testMeasureSubtracting3() {
-        measure {
-            _ = (0..<3000).subtracting3(
-                stride(from: 0, to: 3000, by: 1)
-            )
-        }
-    }
 }


### PR DESCRIPTION
# Fixed bugs

- Fixed reloading animation when media is just moved.
  
  ![Simulator Screen Recording - iPhone 15 Pro - 2023-12-17 at 20 01 02](https://github.com/jrsaruo/MediaViewer/assets/23174349/174b0f5d-7826-4276-a4d1-cab884c3d964)
  
# Demo improvements

- Added media-moving simulations.