### PR TITLE
Fixed the page control bar state

### DIFF
--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -635,6 +635,11 @@ open class MediaViewerViewController: UIPageViewController {
         let progress = min(max(rawProgress, 0), 1)
         
         switch pageControlBar.state {
+        case .collapsing, .collapsed, .expanding, .expanded:
+            // Prevent start when paging is finished and progress is reset to 0.
+            if progress != 0 {
+                pageControlBar.startInteractivePaging(forwards: isMovingToNextPage)
+            }
         case .transitioningInteractively(_, let forwards):
             if progress == 1 {
                 pageControlBar.finishInteractivePaging()
@@ -648,11 +653,6 @@ open class MediaViewerViewController: UIPageViewController {
                 pageControlBar.cancelInteractivePaging()
             } else {
                 pageControlBar.updatePagingProgress(progress)
-            }
-        case .collapsing, .collapsed, .expanding, .expanded:
-            // Prevent start when paging is finished and progress is reset to 0.
-            if progress != 0 {
-                pageControlBar.startInteractivePaging(forwards: isMovingToNextPage)
             }
         case .reloading:
             break

--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -638,10 +638,10 @@ open class MediaViewerViewController: UIPageViewController {
         case .transitioningInteractively(_, let forwards):
             if progress == 1 {
                 pageControlBar.finishInteractivePaging()
-            } else if forwards == isMovingToNextPage {
-                pageControlBar.updatePagingProgress(progress)
-            } else {
+            } else if progress == 0 || forwards != isMovingToNextPage {
                 pageControlBar.cancelInteractivePaging()
+            } else {
+                pageControlBar.updatePagingProgress(progress)
             }
         case .collapsing, .collapsed, .expanding, .expanded:
             // Prevent start when paging is finished and progress is reset to 0.

--- a/Sources/MediaViewer/MediaViewerViewController.swift
+++ b/Sources/MediaViewer/MediaViewerViewController.swift
@@ -639,6 +639,12 @@ open class MediaViewerViewController: UIPageViewController {
             if progress == 1 {
                 pageControlBar.finishInteractivePaging()
             } else if progress == 0 || forwards != isMovingToNextPage {
+                // progress is 0 or direction is changed
+                /*
+                 NOTE:
+                 Since the progress value sometimes jumps over zero,
+                 the direction change is also checked.
+                 */
                 pageControlBar.cancelInteractivePaging()
             } else {
                 pageControlBar.updatePagingProgress(progress)


### PR DESCRIPTION
# Fixed bugs

- Fixed a bug that would break the state of the page control bar and prevent the delete animation from working properly if it tried to go back to the previous page but didn't.
  
  ![Simulator Screen Recording - iPhone 15 Pro - 2024-02-14 at 01 59 08](https://github.com/jrsaruo/MediaViewer/assets/23174349/d5c837d3-0a70-4625-aad6-7d67cf29a06d)